### PR TITLE
Fix bug in run method on python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Example for using the tool
 
 .. code-block:: shell
 
-	$ pip setup.py pyassembly
+	$ python setup.py pyassembly
 
 
 How to get more options

--- a/pyassembly/main.py
+++ b/pyassembly/main.py
@@ -59,7 +59,7 @@ class pyassembly(Command):
 
         # install deps, if needed
         if os.path.exists(self.requirements_file):
-            with tempfile.NamedTemporaryFile() as tf, open(self.requirements_file) as f:
+            with tempfile.NamedTemporaryFile(mode='w+') as tf, open(self.requirements_file) as f:
                 for ln in f:
                     ln = ln.lstrip()
                     if not (ln.startswith("#") or ln.startswith("pyassembly")):

--- a/pyassembly/main.py
+++ b/pyassembly/main.py
@@ -7,7 +7,7 @@ from distutils.cmd import Command
 from distutils.sysconfig import get_python_version
 
 try:
-    from pip._internal.commands import InstallCommand
+    from pip._internal.commands.install import InstallCommand
 except ImportError:  # for pip <= 9.0.3
     from pip.commands import InstallCommand
 
@@ -65,7 +65,10 @@ class pyassembly(Command):
                     if not (ln.startswith("#") or ln.startswith("pyassembly")):
                         tf.write(ln)
                 tf.flush()
-                install_command = InstallCommand(isolated=False)
+                try:
+                    install_command = InstallCommand('install', 'Install packages.', isolated=False)
+                except TypeError:  # pip < 20
+                    install_command = InstallCommand(isolated=False)
                 install_command.main(args=['-r', tf.name, '-t', dist_dir])
 
         bdist_egg = self.distribution.get_command_obj('bdist_egg')  # type: Command

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:  # for pip <= 9.0.3
 from setuptools import setup, find_packages
 
 
-VERSION = "2.1"
+VERSION = "2.2.1-1science"
 PACKAGE_NAME = "pyassembly"
 
 reqs = parse_requirements('requirements.txt', session=False)


### PR DESCRIPTION
Copied code from pypi's latest version (2.2.1)

And then applied a fix for a bug that happens on python 3.7 where calling `write` on `NamedTemporaryFile` raises a TypeError